### PR TITLE
fix(overlay): remove `gnome` scope & bump to `46-mobile.1`

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -11,36 +11,34 @@ let
 in
 
 {
-  gnome = super.gnome.overrideScope (gself: gsuper: {
-    gnome-shell = gsuper.gnome-shell.overrideAttrs (old: rec {
-      version = "46-mobile-0";  # 361fc605e595b36df68d8b691f22bccddcf84cc9
-      src = super.fetchFromGitLab {
-        domain = "gitlab.gnome.org";
-        owner = "verdre";
-        repo = "mobile-shell";
-        rev = version;
-        hash = "sha256-iHDX//QsfDDSv9OnN1E4ZgxVOqzqzNHQC2/ZrAeYUL8=";
-        fetchSubmodules = true;
-      };
-      # JS ERROR: Error: Requiring ModemManager, version none: Typelib file for namespace 'ModemManager' (any version) not found
-      # @resource:///org/gnome/shell/misc/modemManager.js:4:49
-      buildInputs = old.buildInputs ++ [ super.modemmanager ];
-      postPatch = ''
-        patchShebangs src/data-to-c.pl
-        ln -sf ${gvc} subprojects/gvc
-      '';
-    });
+  gnome-shell = super.gnome-shell.overrideAttrs (old: rec {
+    version = "46-mobile-0";  # 361fc605e595b36df68d8b691f22bccddcf84cc9
+    src = super.fetchFromGitLab {
+      domain = "gitlab.gnome.org";
+      owner = "verdre";
+      repo = "mobile-shell";
+      rev = version;
+      hash = "sha256-iHDX//QsfDDSv9OnN1E4ZgxVOqzqzNHQC2/ZrAeYUL8=";
+      fetchSubmodules = true;
+    };
+    # JS ERROR: Error: Requiring ModemManager, version none: Typelib file for namespace 'ModemManager' (any version) not found
+    # @resource:///org/gnome/shell/misc/modemManager.js:4:49
+    buildInputs = old.buildInputs ++ [ super.modemmanager ];
+    postPatch = ''
+      patchShebangs src/data-to-c.pl
+      ln -sf ${gvc} subprojects/gvc
+    '';
+  });
 
-    mutter = gsuper.mutter.overrideAttrs (old: rec {
-      version = "46-mobile-0";  # 805bce1ffa98a4aad180988c7aa7c34115da1d5d
-      src = super.fetchFromGitLab {
-        domain = "gitlab.gnome.org";
-        owner = "verdre";
-        repo = "mobile-mutter";
-        rev = version;
-        hash = "sha256-l2iKUvzW0FPPccQkhd2bDdd+BD4ZHi21MOHLhZCJwbY=";
-      };
-    });
+  mutter = super.mutter.overrideAttrs (old: rec {
+    version = "46-mobile-0";  # 805bce1ffa98a4aad180988c7aa7c34115da1d5d
+    src = super.fetchFromGitLab {
+      domain = "gitlab.gnome.org";
+      owner = "verdre";
+      repo = "mobile-mutter";
+      rev = version;
+      hash = "sha256-l2iKUvzW0FPPccQkhd2bDdd+BD4ZHi21MOHLhZCJwbY=";
+    };
   });
 }
 

--- a/overlay.nix
+++ b/overlay.nix
@@ -12,13 +12,13 @@ in
 
 {
   gnome-shell = super.gnome-shell.overrideAttrs (old: rec {
-    version = "46-mobile-0";  # 361fc605e595b36df68d8b691f22bccddcf84cc9
+    version = "46-mobile.1";
     src = super.fetchFromGitLab {
       domain = "gitlab.gnome.org";
       owner = "verdre";
-      repo = "mobile-shell";
+      repo = "gnome-shell-mobile";
       rev = version;
-      hash = "sha256-iHDX//QsfDDSv9OnN1E4ZgxVOqzqzNHQC2/ZrAeYUL8=";
+      hash = "sha256-NL1/mddfaL1rMidsbtV4kG2SlAZZNuR8KmqTmEE4IAM=";
       fetchSubmodules = true;
     };
     # JS ERROR: Error: Requiring ModemManager, version none: Typelib file for namespace 'ModemManager' (any version) not found
@@ -31,13 +31,13 @@ in
   });
 
   mutter = super.mutter.overrideAttrs (old: rec {
-    version = "46-mobile-0";  # 805bce1ffa98a4aad180988c7aa7c34115da1d5d
+    version = "46-mobile.1";
     src = super.fetchFromGitLab {
       domain = "gitlab.gnome.org";
       owner = "verdre";
-      repo = "mobile-mutter";
+      repo = "mutter-mobile";
       rev = version;
-      hash = "sha256-l2iKUvzW0FPPccQkhd2bDdd+BD4ZHi21MOHLhZCJwbY=";
+      hash = "sha256-Xmoq//Igaz1oVt2/aLV+9WjZzW1g6yLADqg97wD3Lug=";
     };
   });
 }


### PR DESCRIPTION
fix #3 

For cross-compiling `gnome-control-center`, here is another patch: https://github.com/sn0wm1x/os/blob/7bac8ad37200892e2ce1cb5067056076e827dfe7/hosts/enchilada/gnome-mobile/overlay.nix#L47-L56
I didn't add it to this PR because it's not quite relevant.